### PR TITLE
feat: Improve skill editing UX and pagination

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## What changed on this pull request
+
+<!-- Add a summary of the changes made in this pull request -->
+
+### Reference

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    YT: any;
+    onYouTubeIframeAPIReady: () => void;
+  }
+}
+
+export {};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.0.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@ant-design/icons':
         specifier: ^6.0.0
         version: 6.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -184,6 +193,28 @@ packages:
   '@babel/runtime@7.28.3':
     resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -3012,6 +3043,31 @@ snapshots:
       throttle-debounce: 5.0.2
 
   '@babel/runtime@7.28.3': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.0)
+      react: 19.1.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
 
   '@emnapi/core@1.5.0':
     dependencies:

--- a/src/components/VideoDetail.tsx
+++ b/src/components/VideoDetail.tsx
@@ -293,7 +293,7 @@ export function VideoDetail({
                           스킬 순서
                         </h4>
                         <div className="overflow-x-auto">
-                          <table className="border-collapse" style={{width: 'max-content'}}>
+                          <table className="border-collapse" style={{width: 'max-content', margin: '0 auto'}}>
                               <thead>
                                 <tr className="border-b">
                                   <th className="text-left py-2 px-3 font-medium text-sm whitespace-nowrap">
@@ -449,7 +449,7 @@ export function VideoDetail({
                   <div className="bg-card border rounded-lg p-4" style={{width: '0', minWidth: '100%'}}>
                     <h4 className="text-lg font-semibold mb-4">스킬 순서</h4>
                     <div className="overflow-x-auto">
-                      <table className="border-collapse" style={{width: 'max-content'}}>
+                      <table className="border-collapse" style={{width: 'max-content', margin: '0 auto'}}>
                           <thead>
                             <tr className="border-b">
                               <th className="text-left py-2 px-3 font-medium text-sm whitespace-nowrap">

--- a/src/components/YouTubeEmbed.tsx
+++ b/src/components/YouTubeEmbed.tsx
@@ -1,20 +1,95 @@
 "use client"
 
+import { useEffect, useRef } from "react"
+
 interface YouTubeEmbedProps {
   videoId: string
   title?: string
+  onPlayStateChange?: (isPlaying: boolean) => void
 }
 
-export function YouTubeEmbed({ videoId, title = "YouTube 비디오" }: YouTubeEmbedProps) {
+export function YouTubeEmbed({ videoId, title = "YouTube 비디오", onPlayStateChange }: YouTubeEmbedProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!onPlayStateChange) return
+
+    // YouTube Player API 로드
+    const loadYouTubeAPI = () => {
+      if (window.YT) {
+        initPlayer()
+        return
+      }
+
+      const script = document.createElement('script')
+      script.src = 'https://www.youtube.com/iframe_api'
+      script.async = true
+      document.body.appendChild(script)
+
+      window.onYouTubeIframeAPIReady = initPlayer
+    }
+
+    const initPlayer = () => {
+      if (!containerRef.current) return
+
+      // 기존 iframe 제거
+      const existingIframe = containerRef.current.querySelector('iframe')
+      if (existingIframe) {
+        existingIframe.remove()
+      }
+
+      // 플레이어 컨테이너 생성
+      const playerDiv = document.createElement('div')
+      playerDiv.id = `youtube-player-${videoId}`
+      containerRef.current.appendChild(playerDiv)
+
+      new window.YT.Player(playerDiv.id, {
+        videoId: videoId,
+        width: '100%',
+        height: '100%',
+        playerVars: {
+          enablejsapi: 1,
+          origin: window.location.origin
+        },
+        events: {
+          onStateChange: (event: { data: number }) => {
+            const isPlaying = event.data === window.YT.PlayerState.PLAYING
+            onPlayStateChange(isPlaying)
+          }
+        }
+      })
+    }
+
+    loadYouTubeAPI()
+
+    return () => {
+      // cleanup
+      if (containerRef.current) {
+        const iframe = containerRef.current.querySelector('iframe')
+        if (iframe) iframe.remove()
+      }
+    }
+  }, [videoId, onPlayStateChange])
+
+  // onPlayStateChange가 없으면 기본 iframe 사용
+  if (!onPlayStateChange) {
+    return (
+      <div className="relative w-full aspect-video rounded-lg overflow-hidden">
+        <iframe
+          src={`https://www.youtube.com/embed/${videoId}`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="absolute inset-0 w-full h-full"
+        />
+      </div>
+    )
+  }
+
   return (
-    <div className="relative w-full aspect-video rounded-lg overflow-hidden">
-      <iframe
-        src={`https://www.youtube.com/embed/${videoId}`}
-        title={title}
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowFullScreen
-        className="absolute inset-0 w-full h-full"
-      />
-    </div>
+    <div 
+      ref={containerRef}
+      className="relative w-full aspect-video rounded-lg overflow-hidden"
+    />
   )
 }

--- a/src/components/custom/cascader.tsx
+++ b/src/components/custom/cascader.tsx
@@ -106,7 +106,7 @@ export function Cascader({
             {value.length > 0 ? (
               multiple ? (
                 <div className="flex flex-wrap gap-1">
-                  {value.slice(0, 2).map((item, index) => {
+                  {value.map((item, index) => {
                     const displayLabel = (() => {
                       if (item.length === 1) {
                         const parent = options.find(
@@ -128,10 +128,10 @@ export function Cascader({
                     return (
                       <span
                         key={index}
-                        className="inline-flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-0.5 rounded text-xs max-w-32 truncate"
+                        className="inline-flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-0.5 rounded text-xs min-w-0 shrink-0"
                         title={displayLabel}
                       >
-                        <span className="truncate">{displayLabel}</span>
+                        <span className="min-w-0">{displayLabel}</span>
                         <div
                           onClick={(e) => {
                             e.stopPropagation();
@@ -144,11 +144,6 @@ export function Cascader({
                       </span>
                     );
                   })}
-                  {value.length > 2 && (
-                    <span className="text-xs text-muted-foreground">
-                      +{value.length - 2}개 더
-                    </span>
-                  )}
                 </div>
               ) : (
                 <span className="text-sm">

--- a/src/components/custom/multi-select.tsx
+++ b/src/components/custom/multi-select.tsx
@@ -83,15 +83,15 @@ export function MultiSelect({
           <div className="flex-1 text-left truncate">
             {value.length > 0 ? (
               <div className="flex flex-wrap gap-1">
-                {value.slice(0, 3).map((item, index) => {
+                {value.map((item, index) => {
                   const option = options.find((opt) => opt.value === item);
                   return (
                     <span
                       key={index}
-                      className="inline-flex items-center gap-1 bg-red-100 text-red-800 px-2 py-0.5 rounded text-xs max-w-32 truncate"
+                      className="inline-flex items-center gap-1 bg-red-100 text-red-800 px-2 py-0.5 rounded text-xs min-w-0 shrink-0"
                       title={option?.label || item?.toString()}
                     >
-                      <span className="truncate">{option?.label || item}</span>
+                      <span className="min-w-0">{option?.label || item}</span>
                       <div
                         onClick={(e) => removeValue(item, e)}
                         className="ml-1 hover:text-red-600 cursor-pointer flex-shrink-0"
@@ -101,11 +101,6 @@ export function MultiSelect({
                     </span>
                   );
                 })}
-                {value.length > 3 && (
-                  <span className="text-xs text-muted-foreground">
-                    +{value.length - 3}개 더
-                  </span>
-                )}
               </div>
             ) : (
               <span className="text-muted-foreground">{placeholder}</span>


### PR DESCRIPTION
## What changed on this pull request

### 스킬 편집 UX 대폭 개선
- **Picture-in-Picture 영상**: 편집 모드에서 영상이 우상단에 고정되어 항상 참조 가능
- **영상 크기 자동 조절**: 재생 시 확대, 일시정지 시 축소로 최적화된 viewing 경험
- **전체 화면 편집**: 편집 영역이 화면 전체 너비를 활용하여 노트북에서도 충분한 공간 확보

### 스킬 관리 기능 강화
- **컴팩트 모드**: 스킬 목록을 한 줄로 축약하여 더 많은 스킬을 한 화면에 표시
- **드래그 앤 드롭**: 스킬 순서를 직관적으로 변경 가능
- **Floating 추가 버튼**: 긴 목록에서도 쉽게 스킬 추가 가능

### 필터 및 페이지네이션 개선
- **자동 클리어**: 페이지 입력 시 기존 값 자동 삭제
- **스마트 Fallback**: 빈 값 입력 시 1페이지로 자동 이동
- **향상된 필터 UI**: Cascader 및 MultiSelect 컴포넌트 개선

### Background

스킬 편집 시 영상 참조의 불편함과 페이지 이동의 번거로움을 해결하여 전반적인 사용성을 개선했습니다.

🤖 Generated with [Claude Code](https://claude.ai/code)