### PR TITLE
feat: Lunatic 3min score fix + expanded GA event taxonomy

### DIFF
--- a/src/app/calculator/score/page.tsx
+++ b/src/app/calculator/score/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import { useEffect } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RaidScoreCalculator } from "@/components/features/calculator/raid-score-calculator";
 import { TacticalChallengeCalculator } from "@/components/features/calculator/tactical-challenge-calculator";
+import { trackEvent } from "@/utils/analytics";
 
 export default function ScoreCalculatorPage() {
+  useEffect(() => {
+    trackEvent("calculator_use", { type: "raid_score" });
+  }, []);
+
   return (
     <div className="container mx-auto">
       <div className="mb-6">
@@ -16,8 +22,18 @@ export default function ScoreCalculatorPage() {
 
       <Tabs defaultValue="raid" className="w-full">
         <TabsList className="grid w-full max-w-md grid-cols-2">
-          <TabsTrigger value="raid">총력전/대결전</TabsTrigger>
-          <TabsTrigger value="tactical">종합전술시험</TabsTrigger>
+          <TabsTrigger
+            value="raid"
+            onClick={() => trackEvent("calculator_use", { type: "raid_score" })}
+          >
+            총력전/대결전
+          </TabsTrigger>
+          <TabsTrigger
+            value="tactical"
+            onClick={() => trackEvent("calculator_use", { type: "tactical_challenge" })}
+          >
+            종합전술시험
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="raid" className="mt-6">

--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -5,6 +5,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CharacterAvatar } from "@/components/common/character-image";
 import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { trackEvent } from "@/utils/analytics";
+
+function extractVideoIdFromUrl(url: string): string {
+  const m = url.match(/video-analysis\/([^?]+)/);
+  return m ? m[1] : url;
+}
 
 // 편집하기 쉽게 상수로 분리
 const ASSISTANTS = [
@@ -189,7 +195,16 @@ export default function GuidePage() {
                         <div className="flex flex-wrap gap-1 justify-center">
                           {row.extreme.map((url, i) => (
                             <Button key={i} asChild size="sm">
-                              <a href={url} target="_blank" rel="noopener noreferrer">
+                              <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={() =>
+                                  trackEvent("guide_video_click", {
+                                    video_id: extractVideoIdFromUrl(url),
+                                  })
+                                }
+                              >
                                 <ExternalLink />
                                 영상{row.extreme!.length > 1 ? ` ${i + 1}` : ""}
                               </a>
@@ -205,7 +220,16 @@ export default function GuidePage() {
                         <div className="flex flex-wrap gap-1 justify-center">
                           {row.insane.map((url, i) => (
                             <Button key={i} asChild size="sm">
-                              <a href={url} target="_blank" rel="noopener noreferrer">
+                              <a
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={() =>
+                                  trackEvent("guide_video_click", {
+                                    video_id: extractVideoIdFromUrl(url),
+                                  })
+                                }
+                              >
                                 <ExternalLink />
                                 영상{row.insane!.length > 1 ? ` ${i + 1}` : ""}
                               </a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import {
@@ -10,12 +12,14 @@ import { Badge } from "@/components/ui/badge";
 import { Search, PieChart, Video, Calculator, Sprout, Heart } from "lucide-react";
 import { SupportModal } from "@/components/common/support-modal";
 import { Button } from "@/components/ui/button";
+import { trackEvent } from "@/utils/analytics";
 
 const features = [
   {
     title: "파티 찾기 & 요약",
     description: "시즌별 파티 정보와 요약을 볼 수 있어요.",
     href: "/party",
+    feature: "party_search" as const,
     icon: Search,
     color: "text-blue-500",
     bgColor: "bg-blue-500/10",
@@ -24,6 +28,7 @@ const features = [
     title: "분석",
     description: "전체 총력전 추이와 캐릭터별 통계를 볼 수 있어요.",
     href: "/analysis",
+    feature: "total_analysis" as const,
     icon: PieChart,
     color: "text-purple-500",
     bgColor: "bg-purple-500/10",
@@ -32,6 +37,7 @@ const features = [
     title: "영상",
     description: "Youtube에 올라온 클리어 영상들이에요.",
     href: "/video-analysis",
+    feature: "video" as const,
     icon: Video,
     color: "text-rose-500",
     bgColor: "bg-rose-500/10",
@@ -40,6 +46,7 @@ const features = [
     title: "ARONA",
     description: "아로나에게 궁금한 것을 물어보세요!",
     href: "/arona",
+    feature: "arona" as const,
     image: "/arona.webp",
     badge: "Beta",
   },
@@ -47,6 +54,7 @@ const features = [
     title: "점수 계산기",
     description: "총력전, 대결전, 종합전술시험 점수를 계산할 수 있어요.",
     href: "/calculator/score",
+    feature: "calculator" as const,
     icon: Calculator,
     color: "text-emerald-500",
     bgColor: "bg-emerald-500/10",
@@ -67,7 +75,13 @@ export default function Home() {
       {/* 기능 카드 그리드 */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {features.map((feature) => (
-          <Link key={feature.href} href={feature.href}>
+          <Link
+            key={feature.href}
+            href={feature.href}
+            onClick={() =>
+              trackEvent("home_feature_click", { feature: feature.feature })
+            }
+          >
             <Card className="h-full hover:shadow-lg transition-shadow cursor-pointer hover:border-primary/50">
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-3">
@@ -104,7 +118,12 @@ export default function Home() {
 
       {/* 입문 가이드 배너 */}
       <div className="mt-4">
-        <Link href="/guide">
+        <Link
+          href="/guide"
+          onClick={() =>
+            trackEvent("home_feature_click", { feature: "guide" })
+          }
+        >
           <div className="flex items-center gap-3 px-4 py-3 rounded-lg border border-[#27a567]/40 bg-[#27a567]/10 hover:bg-[#27a567]/20 transition-colors cursor-pointer">
             <Sprout className="w-5 h-5 text-[#27a567] shrink-0" />
             <span className="text-sm font-medium text-[#27a567]">총력전이 처음이신가요?</span>

--- a/src/app/party/page.tsx
+++ b/src/app/party/page.tsx
@@ -6,7 +6,7 @@ import RaidSearch from "@/components/features/raid/raid-search";
 import RaidSummary from "@/components/features/raid/raid-summary";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SingleSelect } from "@/components/ui/custom/single-select";
-import { trackSummaryTabClick } from "@/utils/analytics";
+import { trackEvent } from "@/utils/analytics";
 import { useStudentMaps } from "@/hooks/use-student-maps";
 import { useRaids } from "@/hooks/use-raids";
 
@@ -107,7 +107,12 @@ export default function PartyPage() {
           <TabsTrigger value="search">파티 찾기</TabsTrigger>
           <TabsTrigger
             value="summary"
-            onClick={() => trackSummaryTabClick("summary")}
+            onClick={() =>
+              trackEvent("summary_view", {
+                season,
+                difficulty: effectiveSummaryLevel === "L" ? "lunatic" : "torment",
+              })
+            }
           >
             요약
           </TabsTrigger>
@@ -127,9 +132,10 @@ export default function PartyPage() {
               onValueChange={(v) => {
                 const next = v as "T" | "L";
                 setSummaryLevel(next);
-                trackSummaryTabClick(
-                  next === "L" ? "summary-lunatic" : "summary"
-                );
+                trackEvent("summary_view", {
+                  season,
+                  difficulty: next === "L" ? "lunatic" : "torment",
+                });
               }}
               className="w-full"
             >

--- a/src/app/video-analysis/[id]/edit/page.tsx
+++ b/src/app/video-analysis/[id]/edit/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react";
 import { YouTubeEmbed } from "@/components/features/video/youtube-embed";
 import { EditableAnalysisResult } from "../_components/editable-analysis-result";
 import { VideoAnalysisData } from "@/types/video";
+import { trackEvent } from "@/utils/analytics";
 
 interface EditVideoData {
   videos: VideoAnalysisData[];
@@ -23,6 +24,10 @@ export default function VideoEditPage() {
 
   const [currentVideo, setCurrentVideo] = useState<VideoAnalysisData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (videoId) trackEvent("video_edit", { video_id: videoId });
+  }, [videoId]);
 
   useEffect(() => {
     if (!raidId) {

--- a/src/app/video-analysis/_components/video-analysis-content.tsx
+++ b/src/app/video-analysis/_components/video-analysis-content.tsx
@@ -15,6 +15,7 @@ import ErrorPage from "@/components/common/error-page";
 import { generateSearchKeyword } from "@/utils/raid";
 import { PartyFilterSection } from "@/components/features/raid/party-filter-section";
 import Loading from "@/components/common/loading";
+import { trackEvent } from "@/utils/analytics";
 
 interface VideoAnalysisContentProps {
   initialRaid: string;
@@ -115,7 +116,10 @@ export function VideoAnalysisContent({
           <SingleSelect
             options={raidsSelectOptions}
             value={selectedRaid}
-            onChange={handleRaidChange}
+            onChange={(value) => {
+              handleRaidChange(value);
+              trackEvent("video_filter_apply", { raid_filter: value });
+            }}
             placeholder="총력전/대결전 선택"
           />
           {selectedRaid !== "all" && (() => {

--- a/src/app/video-analysis/_components/video-list.tsx
+++ b/src/app/video-analysis/_components/video-list.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import { VideoListItem } from "@/types/video";
 import { useRaids } from "@/hooks/use-raids";
-import { trackVideoClick } from "@/utils/analytics";
+import { trackEvent } from "@/utils/analytics";
 
 interface VideoListProps {
   videos: VideoListItem[];
@@ -84,11 +84,12 @@ export function VideoList({ videos }: VideoListProps) {
               key={video.video_id}
               href={href}
               onClick={() =>
-                trackVideoClick(
-                  video.video_id,
-                  video.raid_id || "unknown",
-                  video.score
-                )
+                trackEvent("video_open", {
+                  source: "video_list",
+                  video_id: video.video_id,
+                  raid_id: video.raid_id || "unknown",
+                  ...(video.score !== undefined ? { score: video.score } : {}),
+                })
               }
             >
               <Card className="cursor-pointer hover:shadow-lg transition-shadow bg-card border-border h-full flex flex-col overflow-hidden p-0">

--- a/src/components/features/ai-search/ApiKeyModal.tsx
+++ b/src/components/features/ai-search/ApiKeyModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ExternalLink, Key, AlertTriangle } from "lucide-react";
+import { trackEvent } from "@/utils/analytics";
 
 interface ApiKeyModalProps {
   open: boolean;
@@ -41,6 +42,7 @@ export function ApiKeyModal({
     }
 
     setError("");
+    trackEvent("arona_apikey_set");
     onSubmit(apiKey.trim());
     onOpenChange(false);
   };

--- a/src/components/features/ai-search/hooks/useChat.ts
+++ b/src/components/features/ai-search/hooks/useChat.ts
@@ -7,6 +7,7 @@ import type {
   StreamMessage,
 } from "@/types/ai-search";
 import { getStatusMessage, getToolResultMessage, AI_SEARCH_FALLBACK_MESSAGE } from "@/constants/ai-search";
+import { trackEvent } from "@/utils/analytics";
 
 interface UseChatProps {
   apiKey: string | null;
@@ -67,10 +68,12 @@ export function useChat({ apiKey, personaPrompt, instructionPrompt, onApiKeyRequ
     if (!input.trim() || isLoading) return;
 
     if (!apiKey) {
+      trackEvent("arona_query_send", { has_api_key: false });
       onApiKeyRequired();
       return;
     }
 
+    trackEvent("arona_query_send", { has_api_key: true });
     const question = input.trim();
     setInput("");
     setError(null);

--- a/src/components/features/pool/pool-editor-dialog.tsx
+++ b/src/components/features/pool/pool-editor-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -16,6 +16,7 @@ import useStudentPoolStore from "@/store/useStudentPoolStore";
 import PoolToolbar from "./pool-toolbar";
 import PoolStudentGrid from "./pool-student-grid";
 import PresetPopover from "@/components/features/preset/preset-popover";
+import { trackEvent } from "@/utils/analytics";
 
 interface PoolEditorDialogProps {
   open: boolean;
@@ -33,14 +34,31 @@ export default function PoolEditorDialog({
   const pool = useStudentPoolStore((state) => state.pool);
   const setAll = useStudentPoolStore((state) => state.setAll);
   const [searchQuery, setSearchQuery] = useState("");
+  const initialOwnedCountRef = useRef<number | null>(null);
 
   const ownedCount = useMemo(
     () => Object.keys(pool.students).length,
     [pool.students]
   );
 
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      trackEvent("party_search_pool_open");
+      initialOwnedCountRef.current = ownedCount;
+    } else {
+      if (
+        initialOwnedCountRef.current !== null &&
+        initialOwnedCountRef.current !== ownedCount
+      ) {
+        trackEvent("party_search_pool_save");
+      }
+      initialOwnedCountRef.current = null;
+    }
+    onOpenChange(next);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-3xl max-h-[90vh] flex flex-col p-0 gap-0">
         <DialogHeader className="px-6 pt-6 pb-3">
           <DialogTitle className="flex items-center gap-2">

--- a/src/components/features/raid/party-card.tsx
+++ b/src/components/features/raid/party-card.tsx
@@ -12,7 +12,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import SingleParty from "./single-party";
-import { trackVideoClick } from "@/utils/analytics";
+import { trackEvent } from "@/utils/analytics";
 
 interface PartyCardProps {
   rank: number;
@@ -44,7 +44,12 @@ const PartyCard: React.FC<PartyCardProps> = ({
   );
   const handleVideoClick = React.useCallback(() => {
     if (video_id && raid_id) {
-      trackVideoClick(video_id, raid_id, value);
+      trackEvent("video_open", {
+        source: "party_card",
+        video_id,
+        raid_id,
+        score: value,
+      });
       window.open(`/video-analysis/${video_id}?raid_id=${raid_id}`, "_blank");
     }
   }, [video_id, raid_id, value]);

--- a/src/components/features/raid/raid-summary/index.tsx
+++ b/src/components/features/raid/raid-summary/index.tsx
@@ -23,6 +23,28 @@ import {
   createPartyCountData,
 } from "./utils/raidDataTransform";
 import { generateSearchKeyword } from "@/utils/raid";
+import { useSectionView } from "@/hooks/use-section-view";
+
+function SummarySection({
+  section,
+  children,
+}: {
+  section:
+    | "platinum_stats"
+    | "essential_chars"
+    | "high_impact_chars"
+    | "top_assistants"
+    | "top_5_party"
+    | "min_ue_clear"
+    | "max_party_clear"
+    | "party_composition"
+    | "character_usage_table"
+    | "character_growth_stats";
+  children: React.ReactNode;
+}) {
+  const ref = useSectionView("summary_section_view", section);
+  return <div ref={ref}>{children}</div>;
+}
 
 const RaidSummary = ({
   season,
@@ -195,104 +217,126 @@ const RaidSummary = ({
         </button>
 
         {level !== "I" && (
-          <PlatinumStats
-            clearCount={data.clearCount || 0}
-            clearPercent={level === "T" ? tormentClearPercent : lunaticClearPercent}
-            platinumCuts={data.platinumCuts || []}
-            partPlatinumCuts={data.partPlatinumCuts}
-            lunaticClearPercent={
-              level === "T" && lunaticSummaryData.clearCount > 0 ? lunaticClearPercent : undefined
-            }
-          />
+          <SummarySection section="platinum_stats">
+            <PlatinumStats
+              clearCount={data.clearCount || 0}
+              clearPercent={level === "T" ? tormentClearPercent : lunaticClearPercent}
+              platinumCuts={data.platinumCuts || []}
+              partPlatinumCuts={data.partPlatinumCuts}
+              lunaticClearPercent={
+                level === "T" && lunaticSummaryData.clearCount > 0 ? lunaticClearPercent : undefined
+              }
+            />
+          </SummarySection>
         )}
       </div>
 
       <div className="space-y-6">
         {data.essentialCharacters && data.essentialCharacters.length > 0 && (
-          <EssentialCharacters data={data.essentialCharacters} studentsMap={studentsMap} />
+          <SummarySection section="essential_chars">
+            <EssentialCharacters data={data.essentialCharacters} studentsMap={studentsMap} />
+          </SummarySection>
         )}
 
         {data.highImpactCharacters && data.highImpactCharacters.length > 0 && (
-          <HighImpactCharacters data={data.highImpactCharacters} studentsMap={studentsMap} />
+          <SummarySection section="high_impact_chars">
+            <HighImpactCharacters data={data.highImpactCharacters} studentsMap={studentsMap} />
+          </SummarySection>
         )}
 
-        {assistData.length > 0 && <TopAssistants data={assistData.slice(0, 3)} />}
+        {assistData.length > 0 && (
+          <SummarySection section="top_assistants">
+            <TopAssistants data={assistData.slice(0, 3)} />
+          </SummarySection>
+        )}
 
-        <CardWrapper
-          icon={<Users className="h-5 w-5 text-sky-500" />}
-          title="Top 5 Party"
-          description="전용무기와 배치는 표시되지 않아요."
-        >
-          <div className="space-y-3">
-            {(data.top5Partys || []).map(([party_string, count], idx) => {
-              const students = party_string.split("_").map(Number);
-              const parties = [];
-              for (let i = 0; i < students.length; i += 6) {
-                parties.push(students.slice(i, i + 6));
-              }
-              return (
-                <PartyCard
-                  key={idx}
-                  rank={idx + 1}
-                  value={count}
-                  valueSuffix="명 사용"
-                  parties={parties}
-                />
-              );
-            })}
-          </div>
-        </CardWrapper>
+        <SummarySection section="top_5_party">
+          <CardWrapper
+            icon={<Users className="h-5 w-5 text-sky-500" />}
+            title="Top 5 Party"
+            description="전용무기와 배치는 표시되지 않아요."
+          >
+            <div className="space-y-3">
+              {(data.top5Partys || []).map(([party_string, count], idx) => {
+                const students = party_string.split("_").map(Number);
+                const parties = [];
+                for (let i = 0; i < students.length; i += 6) {
+                  parties.push(students.slice(i, i + 6));
+                }
+                return (
+                  <PartyCard
+                    key={idx}
+                    rank={idx + 1}
+                    value={count}
+                    valueSuffix="명 사용"
+                    parties={parties}
+                  />
+                );
+              })}
+            </div>
+          </CardWrapper>
+        </SummarySection>
 
         {data.minUEUser && (
-          <CardWrapper
-            icon={<Target className="h-5 w-5 text-sky-500" />}
-            title="최소 전용무기 클리어"
-            description={`전용무기 ${data.minUEUser.ueCount}개로 클리어했어요.`}
-          >
-            <PartyCard
-              rank={data.minUEUser.rank}
-              value={data.minUEUser.score}
-              valueSuffix="점"
-              parties={data.minUEUser.partyData}
-            />
-          </CardWrapper>
+          <SummarySection section="min_ue_clear">
+            <CardWrapper
+              icon={<Target className="h-5 w-5 text-sky-500" />}
+              title="최소 전용무기 클리어"
+              description={`전용무기 ${data.minUEUser.ueCount}개로 클리어했어요.`}
+            >
+              <PartyCard
+                rank={data.minUEUser.rank}
+                value={data.minUEUser.score}
+                valueSuffix="점"
+                parties={data.minUEUser.partyData}
+              />
+            </CardWrapper>
+          </SummarySection>
         )}
 
         {data.maxPartyUser && (
-          <CardWrapper
-            icon={<Users className="h-5 w-5 text-sky-500" />}
-            title="최다 파티 클리어"
-            description={`${data.maxPartyUser.partyData.length}파티로 클리어했어요.`}
-          >
-            <PartyCard
-              rank={data.maxPartyUser.rank}
-              value={data.maxPartyUser.score}
-              valueSuffix="점"
-              parties={data.maxPartyUser.partyData}
-            />
-          </CardWrapper>
+          <SummarySection section="max_party_clear">
+            <CardWrapper
+              icon={<Users className="h-5 w-5 text-sky-500" />}
+              title="최다 파티 클리어"
+              description={`${data.maxPartyUser.partyData.length}파티로 클리어했어요.`}
+            >
+              <PartyCard
+                rank={data.maxPartyUser.rank}
+                value={data.maxPartyUser.score}
+                valueSuffix="점"
+                parties={data.maxPartyUser.partyData}
+              />
+            </CardWrapper>
+          </SummarySection>
         )}
 
-        <PartyCompositionChart data={partyCountData} />
+        <SummarySection section="party_composition">
+          <PartyCompositionChart data={partyCountData} />
+        </SummarySection>
 
-        <CardWrapper
-          icon={<TrendingUp className="h-5 w-5 text-sky-500" />}
-          title="캐릭터 사용률"
-        >
-          <div className="space-y-6">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-              <CharacterUsageTable title="STRIKER" data={strikerData} />
-              <CharacterUsageTable title="SPECIAL" data={specialData} />
-              <CharacterUsageTable title="조력자" data={assistData} />
+        <SummarySection section="character_usage_table">
+          <CardWrapper
+            icon={<TrendingUp className="h-5 w-5 text-sky-500" />}
+            title="캐릭터 사용률"
+          >
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <CharacterUsageTable title="STRIKER" data={strikerData} />
+                <CharacterUsageTable title="SPECIAL" data={specialData} />
+                <CharacterUsageTable title="조력자" data={assistData} />
+              </div>
             </div>
-          </div>
-        </CardWrapper>
+          </CardWrapper>
+        </SummarySection>
 
-        <CharacterGrowthStats
-          filters={data.filters || {}}
-          studentsMap={studentsMap}
-          studentSearchMap={studentSearchMap || {}}
-        />
+        <SummarySection section="character_growth_stats">
+          <CharacterGrowthStats
+            filters={data.filters || {}}
+            studentsMap={studentsMap}
+            studentSearchMap={studentSearchMap || {}}
+          />
+        </SummarySection>
       </div>
     </div>
   );

--- a/src/components/features/raid/search-mode-selector.tsx
+++ b/src/components/features/raid/search-mode-selector.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useSearchModeStore, { type SearchMode } from "@/store/useSearchModeStore";
+import { trackEvent } from "@/utils/analytics";
 
 const MODES: { value: SearchMode; label: string }[] = [
   { value: "filter", label: "필터" },
@@ -17,7 +18,11 @@ export default function SearchModeSelector() {
   return (
     <Tabs
       value={mode}
-      onValueChange={(v) => setMode(v as SearchMode)}
+      onValueChange={(v) => {
+        const next = v as SearchMode;
+        setMode(next);
+        trackEvent("party_search_mode", { mode: next });
+      }}
       className="w-full mb-4"
     >
       <TabsList className="grid w-full grid-cols-3">

--- a/src/components/features/total-analysis/TotalAnalysisLayout.tsx
+++ b/src/components/features/total-analysis/TotalAnalysisLayout.tsx
@@ -15,6 +15,24 @@ import {
 } from "@/components/ui/carousel";
 import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
+import { useSectionView } from "@/hooks/use-section-view";
+
+function AnalysisSection({
+  section,
+  className,
+  children,
+}: {
+  section: "character_analysis" | "lunatic_clear_chart" | "raid_usage_carousel";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const ref = useSectionView("total_analysis_section_view", section);
+  return (
+    <div ref={ref} className={className}>
+      {children}
+    </div>
+  );
+}
 
 export function TotalAnalysisLayout() {
   const { data, isLoading } = useTotalAnalysis();
@@ -56,17 +74,26 @@ export function TotalAnalysisLayout() {
         </p>
       </div>
 
-      <div className="w-full max-w-full md:max-w-[1200px] overflow-hidden px-2 sm:px-4 md:px-0">
+      <AnalysisSection
+        section="character_analysis"
+        className="w-full max-w-full md:max-w-[1200px] overflow-hidden px-2 sm:px-4 md:px-0"
+      >
         <CharacterAnalysis data={data} />
-      </div>
+      </AnalysisSection>
 
       <hr className="w-full max-w-full md:max-w-[1200px]" />
 
-      <div className="w-full max-w-full md:max-w-[1200px] overflow-hidden px-2 sm:px-4 md:px-0">
+      <AnalysisSection
+        section="lunatic_clear_chart"
+        className="w-full max-w-full md:max-w-[1200px] overflow-hidden px-2 sm:px-4 md:px-0"
+      >
         <LunaticClearChart data={data} />
-      </div>
+      </AnalysisSection>
 
-      <div className="w-full max-w-full md:max-w-[1200px] px-2 sm:px-12 md:px-12 overflow-hidden">
+      <AnalysisSection
+        section="raid_usage_carousel"
+        className="w-full max-w-full md:max-w-[1200px] px-2 sm:px-12 md:px-12 overflow-hidden"
+      >
         <Carousel
           opts={{
             loop: true,
@@ -116,7 +143,7 @@ export function TotalAnalysisLayout() {
             />
           ))}
         </div>
-      </div>
+      </AnalysisSection>
     </div>
   );
 }

--- a/src/constants/score.ts
+++ b/src/constants/score.ts
@@ -45,7 +45,7 @@ export const scoreInfo = {
     lunatic: {
         fourAndHalfMinuteBase: 44664000,
         fourMinuteBase: 44025000,
-        threeMinuteBase: 44025000, // Not confirmed
+        threeMinuteBase: 43235000,
         timeBonus: 2880
     }
 }

--- a/src/hooks/use-section-view.ts
+++ b/src/hooks/use-section-view.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { trackEvent, type AnalyticsEvent } from "@/utils/analytics";
+
+type SectionEvent = Extract<
+  AnalyticsEvent,
+  { name: "summary_section_view" | "total_analysis_section_view" }
+>;
+
+/**
+ * 섹션이 화면에 50% 이상 1.5초 노출되면 1회 발화. 발화 후 observer 해제.
+ */
+export function useSectionView<E extends SectionEvent>(
+  name: E["name"],
+  section: string,
+) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let fired = false;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+            if (!timer && !fired) {
+              timer = setTimeout(() => {
+                fired = true;
+                trackEvent(name, { section } as E["params"]);
+                observer.disconnect();
+              }, 1500);
+            }
+          } else if (timer) {
+            clearTimeout(timer);
+            timer = null;
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(el);
+    return () => {
+      if (timer) clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [name, section]);
+
+  return ref;
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,39 +1,42 @@
 import { sendGAEvent } from '@next/third-parties/google';
 
-/**
- * Google Analytics 이벤트를 전송합니다
- * @param eventName 이벤트 이름
- * @param params 이벤트 파라미터
- */
-function trackEvent(eventName: string, params?: Record<string, string | number>) {
-  if (params) {
-    sendGAEvent('event', eventName, params);
-  } else {
-    sendGAEvent('event', eventName, {});
-  }
-}
+type Difficulty = 'normal' | 'hard' | 'veryHard' | 'hardcore' | 'extreme' | 'insane' | 'torment' | 'lunatic';
+type TimeLimit = '3min' | '4min' | '4min30s';
 
-/**
- * 요약 탭 클릭 이벤트
- */
-export function trackSummaryTabClick(tabType: 'summary' | 'summary-lunatic') {
-  trackEvent('summary_tab_click', {
-    tab_type: tabType,
-  });
-}
+type SummarySection =
+  | 'platinum_stats'
+  | 'essential_chars'
+  | 'high_impact_chars'
+  | 'top_assistants'
+  | 'top_5_party'
+  | 'min_ue_clear'
+  | 'max_party_clear'
+  | 'party_composition'
+  | 'character_usage_table'
+  | 'character_growth_stats';
 
-/**
- * YouTube 영상 클릭 이벤트
- */
-export function trackVideoClick(videoId: string, raidId: string, score?: number) {
-  const params: Record<string, string | number> = {
-    video_id: videoId,
-    raid_id: raidId,
-  };
+type TotalAnalysisSection = 'character_analysis' | 'lunatic_clear_chart' | 'raid_usage_carousel';
 
-  if (score !== undefined) {
-    params.score = score;
-  }
+type VideoSource = 'party_card' | 'video_list' | 'video_detail' | 'guide' | 'home';
 
-  trackEvent('video_click', params);
+type HomeFeature = 'calculator' | 'party_search' | 'video' | 'arona' | 'guide' | 'total_analysis';
+
+export type AnalyticsEvent =
+  | { name: 'home_feature_click'; params: { feature: HomeFeature } }
+  | { name: 'calculator_use'; params: { type: 'raid_score' | 'tactical_challenge'; difficulty?: Difficulty; timeLimit?: TimeLimit } }
+  | { name: 'party_search_mode'; params: { mode: 'filter' | 'pool' | 'single' } }
+  | { name: 'party_search_pool_open'; params?: undefined }
+  | { name: 'party_search_pool_save'; params?: undefined }
+  | { name: 'summary_view'; params: { season: string; difficulty: 'torment' | 'lunatic' } }
+  | { name: 'summary_section_view'; params: { section: SummarySection } }
+  | { name: 'total_analysis_section_view'; params: { section: TotalAnalysisSection } }
+  | { name: 'video_open'; params: { source: VideoSource; video_id: string; raid_id?: string; score?: number } }
+  | { name: 'video_filter_apply'; params: { raid_filter: string } }
+  | { name: 'video_edit'; params: { video_id: string } }
+  | { name: 'arona_query_send'; params: { has_api_key: boolean } }
+  | { name: 'arona_apikey_set'; params?: undefined }
+  | { name: 'guide_video_click'; params: { video_id: string } };
+
+export function trackEvent<E extends AnalyticsEvent>(name: E['name'], params?: E['params']) {
+  sendGAEvent('event', name, (params ?? {}) as Record<string, string | number | boolean>);
 }


### PR DESCRIPTION
## Summary

- Fix Lunatic 3-minute assault base score (`44025000` → `43235000`); previously identical to the 4-minute base, hiding time-bonus differences in the calculator.
- Replace ad-hoc tracking (`summary_tab_click`, `video_click`) with a typed GA event catalog so we can answer "which features are used" and "which are dead weight" from GA4 Explorations.

### Event catalog

| Category | Event | Notes |
| --- | --- | --- |
| home | `home_feature_click` | feature card / guide banner click |
| calculator | `calculator_use` | type=`raid_score` \| `tactical_challenge` |
| party_search | `party_search_mode` | filter / pool / single |
| party_search | `party_search_pool_open` / `party_search_pool_save` | pool dialog open vs saved-with-changes (drop-off funnel) |
| summary | `summary_view` | season + difficulty (Torment/Lunatic) |
| summary | `summary_section_view` | 10 sections, IntersectionObserver |
| total_analysis | `total_analysis_section_view` | 3 sections, IntersectionObserver |
| video | `video_open` | source=`party_card` \| `video_list` \| `guide` \| `home` |
| video | `video_filter_apply` / `video_edit` | |
| arona | `arona_query_send` (with `has_api_key`) / `arona_apikey_set` | onboarding funnel |
| guide | `guide_video_click` | |

### Visibility tracking

`useSectionView` hook fires once per page-load when a section is ≥50% visible for ≥1.5s, then disconnects the observer. Used for summary and total-analysis sections where the user has no interaction signal but we still want "did they actually look at this?" data.

## Test plan

- [x] Open each top-level page, verify events in GA4 DebugView
- [ ] Confirm `video_open` source differs between party-card click and video-list click
- [ ] Pool editor: open without changes → only `_open` fires; open + add/remove → both `_open` and `_save` fire
- [ ] Scroll past summary sections → `summary_section_view` fires once per section
- [x] Calculator score (Lunatic, 3min vs 4min) now produces different totals
