### PR TITLE
fix: replace sendGAEvent with window.gtag for reliable custom params

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     YT: unknown;
     onYouTubeIframeAPIReady: () => void;
+    gtag: (...args: unknown[]) => void;
   }
 }
 

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,5 +1,3 @@
-import { sendGAEvent } from '@next/third-parties/google';
-
 type Difficulty = 'normal' | 'hard' | 'veryHard' | 'hardcore' | 'extreme' | 'insane' | 'torment' | 'lunatic';
 type TimeLimit = '3min' | '4min' | '4min30s';
 
@@ -38,5 +36,7 @@ export type AnalyticsEvent =
   | { name: 'guide_video_click'; params: { video_id: string } };
 
 export function trackEvent<E extends AnalyticsEvent>(name: E['name'], params?: E['params']) {
-  sendGAEvent('event', name, (params ?? {}) as Record<string, string | number | boolean>);
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', name, params ?? {});
+  }
 }


### PR DESCRIPTION
## Summary
- Replace sendGAEvent from @next/third-parties with direct window.gtag() calls
- Fixes GA4 custom dimension/metric (not set) issue caused by dataLayer parameter association bug (vercel/next.js#61703)
- Applies to ALL custom event parameters (section, feature, mode, video_id, etc.)
- Minor bundle size reduction from removing sendGAEvent import

## Test plan
- [ ] Deploy to preview, trigger events (section scroll, calculator use, video open)
- [ ] Verify in GA4 DebugView that custom parameters are attached to events
- [ ] Monitor GA4 reports for reduced (not set) entries over 48h

Lint, type check, build passed.