### PR TITLE
fix(analytics): correct GA4 event params and exposure tracking

### DIFF
--- a/src/app/party/page.tsx
+++ b/src/app/party/page.tsx
@@ -6,7 +6,6 @@ import RaidSearch from "@/components/features/raid/raid-search";
 import RaidSummary from "@/components/features/raid/raid-summary";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SingleSelect } from "@/components/ui/custom/single-select";
-import { trackEvent } from "@/utils/analytics";
 import { useStudentMaps } from "@/hooks/use-student-maps";
 import { useRaids, getRaidName } from "@/hooks/use-raids";
 import { useTranslations } from "@/lib/i18n";
@@ -106,16 +105,7 @@ export default function PartyPage() {
       <br />
       <Tabs
         value={PartyTab}
-        onValueChange={(v) => {
-          const tab = v as "search" | "summary";
-          setPartyTab(tab);
-          if (tab === "summary") {
-            trackEvent("summary_view", {
-              season,
-              difficulty: effectiveSummaryLevel === "L" ? "lunatic" : "torment",
-            });
-          }
-        }}
+        onValueChange={(v) => setPartyTab(v as "search" | "summary")}
         className="w-full max-w-4xl"
       >
         <TabsList className="grid w-full grid-cols-2">
@@ -134,14 +124,7 @@ export default function PartyPage() {
           {hasLunatic ? (
             <Tabs
               value={summaryLevel}
-              onValueChange={(v) => {
-                const next = v as "T" | "L";
-                setSummaryLevel(next);
-                trackEvent("summary_view", {
-                  season,
-                  difficulty: next === "L" ? "lunatic" : "torment",
-                });
-              }}
+              onValueChange={(v) => setSummaryLevel(v as "T" | "L")}
               className="w-full"
             >
               <TabsList className="grid w-full grid-cols-2 mb-4">

--- a/src/app/video-analysis/_components/video-list.tsx
+++ b/src/app/video-analysis/_components/video-list.tsx
@@ -142,7 +142,7 @@ export function VideoList({ videos }: VideoListProps) {
               href={href}
               onClick={() =>
                 trackEvent("video_open", {
-                  source: "video_list",
+                  video_source: "video_list",
                   video_id: video.video_id,
                   raid_id: video.raid_id || "unknown",
                   ...(video.score !== undefined ? { score: video.score } : {}),

--- a/src/components/features/raid/party-card.tsx
+++ b/src/components/features/raid/party-card.tsx
@@ -47,7 +47,7 @@ const PartyCard: React.FC<PartyCardProps> = ({
   const handleVideoClick = React.useCallback(() => {
     if (video_id && raid_id) {
       trackEvent("video_open", {
-        source: "party_card",
+        video_source: "party_card",
         video_id,
         raid_id,
         score: value,

--- a/src/components/features/raid/raid-summary/index.tsx
+++ b/src/components/features/raid/raid-summary/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "./utils/raidDataTransform";
 import { generateSearchKeyword } from "@/utils/raid";
 import { useSectionView } from "@/hooks/use-section-view";
+import { trackEvent } from "@/utils/analytics";
 import { useTranslations } from "@/lib/i18n";
 
 /* ------------------------------------------------------------------ */
@@ -209,6 +210,15 @@ const RaidSummary = ({
   const { t } = useTranslations();
   const [copied, setCopied] = useState(false);
   const [showAllAssists, setShowAllAssists] = useState(false);
+
+  // 탭 클릭이 아니라 요약 노출 기준으로 발화 — localStorage로 복원된 진입과
+  // 요약을 보는 중의 시즌/난이도 변경까지 모두 집계된다.
+  useEffect(() => {
+    trackEvent("summary_view", {
+      season,
+      difficulty: level === "L" ? "lunatic" : "torment",
+    });
+  }, [season, level]);
 
   const searchKeyword = generateSearchKeyword(
     seasonNameKo ?? seasonDescription ?? "",

--- a/src/components/features/raid/search-mode-selector.tsx
+++ b/src/components/features/raid/search-mode-selector.tsx
@@ -17,6 +17,11 @@ export default function SearchModeSelector() {
   const mode = useSearchModeStore((s) => s.mode);
   const setMode = useSearchModeStore((s) => s.setMode);
 
+  // 전환 클릭만 잡으면 localStorage로 복원된 초기 모드가 누락되므로 진입 시 1회 발화
+  React.useEffect(() => {
+    trackEvent("party_search_mode", { mode: useSearchModeStore.getState().mode });
+  }, []);
+
   return (
     <Tabs
       value={mode}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -24,7 +24,8 @@ export type AnalyticsEvent =
   | { name: 'summary_view'; params: { season: string; difficulty: 'torment' | 'lunatic' } }
   | { name: 'summary_section_view'; params: { section: SummarySection } }
   | { name: 'total_analysis_section_view'; params: { section: TotalAnalysisSection } }
-  | { name: 'video_open'; params: { source: VideoSource; video_id: string; raid_id?: string; score?: number } }
+  // GA가 자동 수집하는 트래픽 소스 파라미터 `source`와 충돌하므로 `video_source` 사용
+  | { name: 'video_open'; params: { video_source: VideoSource; video_id: string; raid_id?: string; score?: number } }
   | { name: 'video_filter_apply'; params: { raid_filter: string } }
   | { name: 'video_edit'; params: { video_id: string } }
   | { name: 'arona_query_send'; params: { has_api_key: boolean } }


### PR DESCRIPTION
Three GA4 event-tracking fixes surfaced by a Data API audit (the `source` dimension showed referrer values; `party_search_mode`/`summary_view` counts looked too low).

## What changed
- **`video_open`: `source` -> `video_source`** — the param name `source` collided with GA4's auto-collected traffic-source dimension, polluting the custom dimension with referrer values (google, naver, bing, t.co...). Renamed so it carries only the intended `party_card`/`video_list`.
- **`party_search_mode` fires on mount** — previously only on tab-switch clicks, so the default mode and modes restored from `localStorage` were never counted (count reflected switches, not exposure).
- **`summary_view` fires on summary exposure** — moved from the two tab `onValueChange` handlers into `RaidSummary` (`[season, level]` effect). `PartyTab` persists in `localStorage`, so returning users landing directly on the summary tab were uncounted; season changes while viewing were missed too. Now covers restored entries, tab switches, difficulty switches, and season changes uniformly.

## Ops / data caveats
- After deploy, register an event-scoped custom dimension **`video_source`** in GA4 Admin -> Custom definitions (keep the old `source` dimension for historical data).
- `party_search_mode` and `summary_view` counts increase structurally (now exposure-based) — do not compare across the deploy date; use post-deploy windows only.

### Checks
- stack: typescript-workflow
- status: pass
- changed files: 6 (all in diff)
- failures: none

Verification: eslint, type check (tsc), and next build passed. Event payloads confirmed via local preview dataLayer capture — incl. a `localStorage`-restored entry firing `party_search_mode {mode: single}` and `summary_view {season, difficulty}`.
