### PR TITLE
fix(video): Derive URLs from video ids

### DIFF
--- a/src/app/video-analysis/_components/AddVideoDialog.tsx
+++ b/src/app/video-analysis/_components/AddVideoDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/select";
 import { Plus } from "lucide-react";
 import { addVideoToQueue } from "@/lib/api";
-import { detectVideoPlatform } from "@/types/video";
+import { parseVideoReference } from "@/types/video";
 import { RaidInfo } from "@/types/raid";
 import { getRaidName } from "@/hooks/use-raids";
 import { useTranslations } from "@/lib/i18n";
@@ -33,11 +33,11 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
   const { t, locale } = useTranslations();
   const [isOpen, setIsOpen] = useState(false);
   const [raidId, setRaidId] = useState<string>("");
-  const [youtubeUrl, setYoutubeUrl] = useState<string>("");
+  const [videoInput, setVideoInput] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
 
   const handleAddToQueue = async () => {
-    if (!raidId || !youtubeUrl) {
+    if (!raidId || !videoInput) {
       await Swal.fire({
         title: t("video.add.error.input"),
         text: t("video.add.error.inputBody"),
@@ -47,8 +47,8 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
       return;
     }
 
-    const platform = detectVideoPlatform(youtubeUrl);
-    if (!platform) {
+    const videoReference = parseVideoReference(videoInput);
+    if (!videoReference) {
       await Swal.fire({
         title: t("video.add.error.url"),
         text: t("video.add.error.urlBody"),
@@ -60,13 +60,13 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
 
     try {
       setSubmitting(true);
-      const result = await addVideoToQueue(raidId, youtubeUrl, platform);
+      const result = await addVideoToQueue(raidId, videoReference.video_id, videoReference.platform);
 
       if (result.existingVideo) {
         const { videoId, raidId: existingRaidId } = result.existingVideo;
         setIsOpen(false);
         setRaidId("");
-        setYoutubeUrl("");
+        setVideoInput("");
 
         const swalResult = await Swal.fire({
           title: t("video.add.existing.title"),
@@ -84,7 +84,7 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
 
       setIsOpen(false);
       setRaidId("");
-      setYoutubeUrl("");
+      setVideoInput("");
 
       await Swal.fire({
         title: t("video.add.success"),
@@ -135,8 +135,8 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
           <div>
             <label className="text-sm font-medium mb-2 block">{t("video.add.urlLabel")}</label>
             <Input
-              value={youtubeUrl}
-              onChange={(e) => setYoutubeUrl(e.target.value)}
+              value={videoInput}
+              onChange={(e) => setVideoInput(e.target.value)}
               placeholder={t("video.add.urlPlaceholder")}
             />
           </div>
@@ -150,7 +150,7 @@ export function AddVideoDialog({ raids }: AddVideoDialogProps) {
             </Button>
             <Button
               onClick={handleAddToQueue}
-              disabled={submitting || !raidId || !youtubeUrl}
+              disabled={submitting || !raidId || !videoInput}
             >
               {submitting ? t("video.edit.saving") : t("video.add.submit")}
             </Button>

--- a/src/app/video-analysis/_components/VideoQueueDialog.tsx
+++ b/src/app/video-analysis/_components/VideoQueueDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Clock, RefreshCw } from "lucide-react";
 import { getQueueStatus, QueueItem } from "@/lib/api";
 import { RaidInfo } from "@/types/raid";
+import { buildVideoUrl } from "@/types/video";
 import { getRaidName as getLocalizedRaidName } from "@/hooks/use-raids";
 import { useTranslations } from "@/lib/i18n";
 
@@ -119,7 +120,7 @@ export function VideoQueueDialog({ raids }: VideoQueueDialogProps) {
                         {t("videoAnalysis.queue.raidLabel").replace("{n}", getRaidName(item.raid_id))}
                       </div>
                       <div className="text-xs text-muted-foreground truncate">
-                        {t("videoAnalysis.queue.urlLabel").replace("{n}", item.youtube_url)}
+                        {t("videoAnalysis.queue.urlLabel").replace("{n}", buildVideoUrl(item.platform, item.video_id))}
                       </div>
                     </div>
                     <div className="text-xs text-muted-foreground ml-4">

--- a/src/app/video-analysis/_components/video-detail/index.tsx
+++ b/src/app/video-analysis/_components/video-detail/index.tsx
@@ -75,7 +75,7 @@ export function VideoDetail({
 
   const copyToClipboard = async (video: VideoAnalysisData) => {
     try {
-      const html = generateHTML(video, studentsMap, t);
+      const html = generateHTML(video, studentsMap, t, platform);
       await navigator.clipboard.writeText(html);
       setCopiedId(video.id);
       setTimeout(() => setCopiedId(null), 2000);

--- a/src/app/video-analysis/_components/video-detail/utils/generateHTML.ts
+++ b/src/app/video-analysis/_components/video-detail/utils/generateHTML.ts
@@ -1,25 +1,26 @@
-import { VideoAnalysisData } from "@/types/video";
+import { buildVideoEmbedUrl, platformFromVideoId, VideoAnalysisData, VideoPlatform } from "@/types/video";
 import { getCharacterName, parseCharacterInfo } from "@/utils/character";
 
 export function generateHTML(
   video: VideoAnalysisData,
   studentsMap: Record<string, string>,
-  t?: (key: string) => string
+  t?: (key: string) => string,
+  platform?: VideoPlatform
 ): string {
   const tr = t ?? ((k: string) => k);
   const { analysis_result } = video;
+  const videoPlatform = platform ?? platformFromVideoId(video.video_id);
 
   let html = `
 <div style="font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px;">
   <p style="color: #6b7280; margin-bottom: 20px;">${tr("videoAnalysis.html.totalScore")}: ${analysis_result.score.toLocaleString()}</p>
 
-  <!-- YouTube 임베드 -->
   <div style="margin-bottom: 30px;">
     <iframe
       width="100%"
       height="450"
-      src="https://www.youtube.com/embed/${video.video_id}"
-      title="YouTube video player"
+      src="${buildVideoEmbedUrl(videoPlatform, video.video_id)}"
+      title="Video player"
       frameborder="0"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowfullscreen

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -82,12 +82,10 @@ interface AddVideoToQueueResult {
   }
 }
 
-export async function addVideoToQueue(raidId: string, videoUrl: string, platform?: VideoPlatform): Promise<AddVideoToQueueResult> {
+export async function addVideoToQueue(raidId: string, videoId: string, platform: VideoPlatform): Promise<AddVideoToQueueResult> {
   const response = await fetchAPI<Response>('/video/analysis/queue', {
     method: 'POST',
-    // youtube_url is the backend's field name for the video URL on every
-    // platform; platform is optional and defaults to "youtube" server-side.
-    body: { raid_id: raidId, youtube_url: videoUrl, ...(platform ? { platform } : {}) },
+    body: { raid_id: raidId, video_id: videoId, platform },
     rawResponse: true,
   })
 
@@ -114,7 +112,8 @@ export async function addVideoToQueue(raidId: string, videoUrl: string, platform
 
 export interface QueueItem {
   id: number
-  youtube_url: string
+  video_id: string
+  platform: VideoPlatform
   raid_id: string
   status: 'pending' | 'failed'
   created_at: string

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -27,7 +27,6 @@ export interface AnalysisResult {
   partyData: number[][]
   score: number
   skillOrders: SkillOrder[]
-  url: string
   description?: string
   validation_errors?: string[]
 }
@@ -52,14 +51,51 @@ export function platformFromVideoId(videoId: string): VideoPlatform {
   return videoId.startsWith("BV") ? "bilibili" : "youtube"
 }
 
-// Detects the platform from a user-supplied video URL, or null when the URL is
-// neither YouTube nor Bilibili (so callers can reject unsupported input and let
-// the backend skip parsing). Mirrors the backend extractors: YouTube is matched
-// by host, Bilibili by its bilibili.com / b23.tv host or a BV id anywhere in the
-// URL (logic_youtube / logic_bilibili ExtractVideoID).
-export function detectVideoPlatform(url: string): VideoPlatform | null {
-  if (/youtube\.com|youtu\.be/i.test(url)) return "youtube"
-  if (/bilibili\.com|b23\.tv/i.test(url) || /BV[a-zA-Z0-9]+/.test(url)) return "bilibili"
+export function buildVideoUrl(platform: VideoPlatform, videoId: string): string {
+  if (platform === "bilibili") return `https://www.bilibili.com/video/${videoId}`
+  return `https://www.youtube.com/watch?v=${videoId}`
+}
+
+export function buildVideoEmbedUrl(platform: VideoPlatform, videoId: string): string {
+  if (platform === "bilibili") return `https://player.bilibili.com/player.html?bvid=${videoId}&high_quality=1&autoplay=0`
+  return `https://www.youtube.com/embed/${videoId}`
+}
+
+export interface VideoReference {
+  video_id: string
+  platform: VideoPlatform
+}
+
+export function parseVideoReference(input: string): VideoReference | null {
+  const trimmed = input.trim()
+  const bilibiliMatch = trimmed.match(/BV[a-zA-Z0-9]+/)
+  if (bilibiliMatch) return { video_id: bilibiliMatch[0], platform: "bilibili" }
+
+  const youtubeId = extractYouTubeVideoId(trimmed)
+  if (youtubeId) return { video_id: youtubeId, platform: "youtube" }
+
+  return null
+}
+
+function extractYouTubeVideoId(input: string): string | null {
+  if (/^[a-zA-Z0-9_-]{11}$/.test(input)) return input
+
+  try {
+    const parsed = new URL(input)
+    if (/youtu\.be$/i.test(parsed.hostname)) {
+      const id = parsed.pathname.split("/").filter(Boolean)[0]
+      return id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null
+    }
+    if (/youtube\.com$/i.test(parsed.hostname) || /youtube-nocookie\.com$/i.test(parsed.hostname)) {
+      const queryID = parsed.searchParams.get("v")
+      if (queryID && /^[a-zA-Z0-9_-]{11}$/.test(queryID)) return queryID
+      const pathID = parsed.pathname.match(/\/(?:embed|v)\/([a-zA-Z0-9_-]{11})/)
+      return pathID ? pathID[1] : null
+    }
+  } catch {
+    return null
+  }
+
   return null
 }
 
@@ -107,4 +143,3 @@ export interface VideoDetailResponse {
     thumbnail_url?: string
   }
 }
-


### PR DESCRIPTION
## What changed on this pull request

- Parse pasted YouTube/Bilibili input into video_id + platform before queue submission.
- Display queue URLs and copied analysis HTML by deriving URLs from video_id + platform.
- Remove analysis_result.url from the frontend analysis type.

### Reference

Evidence: austincli agent check PASS, stack typescript-workflow, changed files 6, failures none.

Depends on BeaverHouse/tinyclover-ba-analyzer#17. Deploy after the ba-analyzer migration/backend rollout is live.