### PR TITLE
feat: Show starting skill orders

### DIFF
--- a/src/components/features/raid/grouped-party-card.tsx
+++ b/src/components/features/raid/grouped-party-card.tsx
@@ -35,6 +35,7 @@ export default function GroupedPartyCard({
         value={party.score}
         valueSuffix={valueSuffix}
         parties={party.partyData}
+        skillOrders={party.skillOrders}
         video_id={party.video_id}
         raid_id={party.video_id ? (party.raid_id || season) : undefined}
         missingCodes={representative.missingCodes}
@@ -54,6 +55,7 @@ export default function GroupedPartyCard({
         value={party.score}
         valueSuffix={valueSuffix}
         parties={party.partyData}
+        skillOrders={party.skillOrders}
         video_id={party.video_id}
         raid_id={party.video_id ? (party.raid_id || season) : undefined}
         missingCodes={representative.missingCodes}
@@ -83,6 +85,7 @@ export default function GroupedPartyCard({
                   value={member.party.score}
                   valueSuffix={valueSuffix}
                   parties={member.party.partyData}
+                  skillOrders={member.party.skillOrders}
                   video_id={member.party.video_id}
                   raid_id={
                     member.party.video_id

--- a/src/components/features/raid/party-card.tsx
+++ b/src/components/features/raid/party-card.tsx
@@ -21,6 +21,7 @@ interface PartyCardProps {
   value: number;
   valueSuffix: string;
   parties: number[][];
+  skillOrders?: number[][];
   video_id?: string;
   raid_id?: string;
   /** 단일 파티 매칭된 sub-party 인덱스 (배경 틴트 강조) */
@@ -35,6 +36,7 @@ const PartyCard: React.FC<PartyCardProps> = ({
   value,
   valueSuffix,
   parties,
+  skillOrders,
   video_id,
   raid_id,
   matchedSubPartyIndexes,
@@ -104,6 +106,7 @@ const PartyCard: React.FC<PartyCardProps> = ({
         {parties.slice(0, 4).map((party, partyIdx) => (
           <SingleParty
             party={party}
+            skillOrders={skillOrders?.[partyIdx]}
             key={"party" + partyIdx}
             highlighted={matchedSet.has(partyIdx)}
             showModeBadge={showModeBadge}
@@ -122,6 +125,7 @@ const PartyCard: React.FC<PartyCardProps> = ({
                   {parties.slice(4).map((party, partyIdx) => (
                     <SingleParty
                       party={party}
+                      skillOrders={skillOrders?.[partyIdx + 4]}
                       key={"party" + partyIdx}
                       highlighted={matchedSet.has(partyIdx + 4)}
                       showModeBadge={showModeBadge}

--- a/src/components/features/raid/raid-search.tsx
+++ b/src/components/features/raid/raid-search.tsx
@@ -435,6 +435,7 @@ const RaidSearch = ({ season, studentsMap, studentSearchMap }: RaidComponentProp
                     value={party.score}
                     valueSuffix={t("party.filter.score").replace("{n}", "").trim()}
                     parties={party.partyData}
+                    skillOrders={party.skillOrders}
                     video_id={party.video_id}
                     raid_id={party.video_id ? (party.raid_id || season) : undefined}
                     matchedSubPartyIndexes={matchedSubPartyIndexes}

--- a/src/components/features/raid/raid-summary/index.tsx
+++ b/src/components/features/raid/raid-summary/index.tsx
@@ -685,6 +685,7 @@ const RaidSummary = ({
                       value={data.minUEUser.score}
                       valueSuffix={t("common.points")}
                       parties={data.minUEUser.partyData}
+                      skillOrders={data.minUEUser.skillOrders}
                     />
                   </div>
                 )}
@@ -706,6 +707,7 @@ const RaidSummary = ({
                       value={data.maxPartyUser.score}
                       valueSuffix={t("common.points")}
                       parties={data.maxPartyUser.partyData}
+                      skillOrders={data.maxPartyUser.skillOrders}
                     />
                   </div>
                 )}

--- a/src/components/features/raid/single-party.tsx
+++ b/src/components/features/raid/single-party.tsx
@@ -5,6 +5,7 @@ import StudentImage from "../student/student-image";
 
 interface SinglePartyProps {
   party: number[];
+  skillOrders?: number[];
   /** 이 sub-party가 조합 매칭된 경우 강조 표시 (배경 틴트만) */
   highlighted?: boolean;
   showModeBadge?: boolean;
@@ -15,30 +16,43 @@ interface SinglePartyProps {
  * Single party component
  * @param party Student codes of the party. 0 is empty slot
  */
-export function SingleParty({ party, highlighted = false, showModeBadge, missingCodes }: SinglePartyProps) {
+export function SingleParty({
+  party,
+  skillOrders,
+  highlighted = false,
+  showModeBadge,
+  missingCodes,
+}: SinglePartyProps) {
   // If party member is lower than 6, insert zero between the last 1xxxx(1xxxxxxx) and 2xxxx(2xxxxxxx)
   const finalParty = React.useMemo(() => {
-    if (party.length >= 6) return party;
+    const slots = party.map((student, index) => ({
+      student,
+      skillOrder: skillOrders?.[index],
+    }));
+    if (slots.length >= 6) return slots;
 
-    const strikers = party.filter((code) => {
-      if (code === 0) return false;
+    const strikers = slots.filter(({ student }) => {
+      if (student === 0) return false;
       const firstDigit = Math.floor(
-        code / Math.pow(10, Math.floor(Math.log10(code)))
+        student / Math.pow(10, Math.floor(Math.log10(student)))
       );
       return firstDigit === 1;
     });
-    const specials = party.filter((code) => {
-      if (code === 0) return false;
+    const specials = slots.filter(({ student }) => {
+      if (student === 0) return false;
       const firstDigit = Math.floor(
-        code / Math.pow(10, Math.floor(Math.log10(code)))
+        student / Math.pow(10, Math.floor(Math.log10(student)))
       );
       return firstDigit === 2;
     });
 
-    const emptySlots = 6 - party.length;
-    const zeros = Array(emptySlots).fill(0);
+    const emptySlots = 6 - slots.length;
+    const zeros = Array.from({ length: emptySlots }, () => ({
+      student: 0,
+      skillOrder: undefined,
+    }));
     return [...strikers, ...zeros, ...specials];
-  }, [party]);
+  }, [party, skillOrders]);
 
   const containerCls = highlighted
     ? "grid grid-cols-6 gap-2 p-2 mb-1 rounded border bg-sky-500/10"
@@ -46,14 +60,22 @@ export function SingleParty({ party, highlighted = false, showModeBadge, missing
 
   return (
     <div className={containerCls}>
-      {finalParty.map((student, idx) => {
+      {finalParty.map(({ student, skillOrder }, idx) => {
         const key = "student" + idx;
         if (student === 0)
           return <div key={key} className="w-10 h-10 sm:w-12 sm:h-12"></div>;
 
         const studentCode = student < 100000 ? student : Math.floor(student / 1000);
         const isMissing = missingCodes?.has(studentCode) ?? false;
-        return <StudentImage code={student} key={key} showModeBadge={showModeBadge} missing={isMissing} />;
+        return (
+          <StudentImage
+            code={student}
+            key={key}
+            showModeBadge={showModeBadge}
+            missing={isMissing}
+            skillOrder={skillOrder}
+          />
+        );
       })}
     </div>
   );

--- a/src/components/features/student/student-image.tsx
+++ b/src/components/features/student/student-image.tsx
@@ -20,6 +20,7 @@ interface StudentImageProps {
   size?: number;
   showModeBadge?: boolean;
   missing?: boolean;
+  skillOrder?: number;
 }
 
 /**
@@ -27,7 +28,13 @@ interface StudentImageProps {
  * @param code Student code (5-digit or 8-digit)
  * @param name Student name (to use in tooltip)
  */
-export function StudentImage({ code, size = 40, showModeBadge = true, missing = false }: StudentImageProps) {
+export function StudentImage({
+  code,
+  size = 40,
+  showModeBadge = true,
+  missing = false,
+  skillOrder,
+}: StudentImageProps) {
   const { t } = useTranslations();
   const { studentsMap } = useStudentMaps();
 
@@ -60,6 +67,10 @@ export function StudentImage({ code, size = 40, showModeBadge = true, missing = 
   const modeIcon = getModeIcon(studentID);
   const modeLabelKey = getModeLabelKey(studentID);
   const modeLabel = modeLabelKey ? t(modeLabelKey) : undefined;
+  const hasSkillOrder = skillOrder !== undefined && skillOrder >= 1 && skillOrder <= 5;
+  const skillOrderLabel = hasSkillOrder
+    ? t("party.party.skillOrder").replace("{n}", String(skillOrder))
+    : undefined;
 
   return (
     <TooltipProvider>
@@ -89,6 +100,19 @@ export function StudentImage({ code, size = 40, showModeBadge = true, missing = 
                   )}
                 </div>
               )}
+              {hasSkillOrder && (
+                <div
+                  aria-label={skillOrderLabel}
+                  role="img"
+                  className={`absolute -right-1 -top-1 z-10 flex h-5 min-w-5 items-center justify-center rounded-full border-2 border-background px-1 text-[11px] font-bold leading-none shadow-sm ${
+                    skillOrder !== undefined && skillOrder >= 4
+                      ? "bg-sky-500 text-white"
+                      : "bg-amber-400 text-slate-950"
+                  }`}
+                >
+                  {skillOrder}
+                </div>
+              )}
             </div>
             {gradeKey >= 10 && (
               <div
@@ -109,6 +133,7 @@ export function StudentImage({ code, size = 40, showModeBadge = true, missing = 
             {showModeBadge && modeLabel ? ` (${modeLabel})` : ""}
             {isAssist ? " (A)" : ""}
           </p>
+          {skillOrderLabel && <p className="text-xs text-sky-500">{skillOrderLabel}</p>}
         </HybridTooltipContent>
       </HybridTooltip>
     </TooltipProvider>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -215,6 +215,7 @@
   "party.note.full": "Read full report",
   "party.party.missing": "Missing {n}",
   "party.party.morePartys": "Show parties 5+",
+  "party.party.skillOrder": "Starting skill #{n}",
   "party.party.otherCompositions": "Show {n} other comps",
   "party.party.uses": "Used {n} times",
   "party.party.video": "Video",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -215,6 +215,7 @@
   "party.note.full": "전체 리포트 보기",
   "party.party.missing": "미보유 {n}명",
   "party.party.morePartys": "5파티 이후 보기",
+  "party.party.skillOrder": "시작 스킬 {n}번째",
   "party.party.otherCompositions": "다른 편성 {n}개 보기",
   "party.party.uses": "{n}회 사용",
   "party.party.video": "영상",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -215,6 +215,7 @@
   "party.note.full": "查看完整报告",
   "party.party.missing": "未持有 {n} 名",
   "party.party.morePartys": "查看第 5 队及以后",
+  "party.party.skillOrder": "起手技能第 {n} 位",
   "party.party.otherCompositions": "查看其他 {n} 套编成",
   "party.party.uses": "使用 {n} 次",
   "party.party.video": "视频",

--- a/src/types/raid.ts
+++ b/src/types/raid.ts
@@ -14,6 +14,7 @@ export interface PartyData {
   rank: number;
   score: number;
   partyData: number[][];
+  skillOrders?: number[][];
   video_id?: string;
   raid_id?: string;
 }
@@ -104,10 +105,12 @@ export interface RaidSummaryData {
     score: number;
     ueCount: number;
     partyData: number[][];
+    skillOrders?: number[][];
   };
   maxPartyUser?: {
     rank: number;
     score: number;
     partyData: number[][];
+    skillOrders?: number[][];
   };
 }


### PR DESCRIPTION
## What changed on this pull request

- Visualize skill orders that implemented in https://github.com/BeaverHouse/ba-torment-data-process/pull/57


