### PR TITLE
Cut Netlify requests, bandwidth, and function calls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,30 @@
 [build.environment]
   NODE_VERSION = "24"
 
+# Next marks prerendered pages must-revalidate, so every page view reached the
+# function even though the durable cache already held the page: 100% of
+# requests to /help, /party and the rest were function invocations. The pages
+# carry no per-visitor data, so a shared cache serves them all.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Netlify-CDN-Cache-Control = "public, durable, s-maxage=600, stale-while-revalidate=86400"
+
+# 60% of all requests were the same optimized images fetched again, because the
+# response tells browsers to revalidate every time. The URL already encodes the
+# transformation, so a stale one cannot be served under it.
+[[headers]]
+  for = "/_next/image*"
+  [headers.values]
+    Cache-Control = "public, max-age=2592000"
+    Netlify-CDN-Cache-Control = "public, durable, s-maxage=2592000"
+
+# Requested 183 times an hour under the same must-revalidate default.
+[[headers]]
+  for = "/favicon.ico"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
 # Deploy Preview에서만 프록시 설정 (CORS 우회)
 [context.deploy-preview.environment]
   NEXT_PUBLIC_API_URL = "/api/proxy"

--- a/src/app/video-analysis/_components/video-analysis-content.tsx
+++ b/src/app/video-analysis/_components/video-analysis-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { VideoList } from "./video-list";
 import { VideoQueueDialog } from "./VideoQueueDialog";
 import { AddVideoDialog } from "./AddVideoDialog";
@@ -19,13 +20,8 @@ import { PartyFilterSection } from "@/components/features/raid/party-filter-sect
 import Loading from "@/components/common/loading";
 import { trackEvent } from "@/utils/analytics";
 
-interface VideoAnalysisContentProps {
-  initialRaid: string;
-}
-
-export function VideoAnalysisContent({
-  initialRaid,
-}: VideoAnalysisContentProps) {
+export function VideoAnalysisContent() {
+  const initialRaid = useSearchParams().get("raid") || "all";
   const { studentsMap, studentSearchMap } = useStudentMaps();
   const { raids } = useRaids();
   const { t, locale } = useTranslations();

--- a/src/app/video-analysis/page.tsx
+++ b/src/app/video-analysis/page.tsx
@@ -1,11 +1,16 @@
+import { Suspense } from "react";
+import Loading from "@/components/common/loading";
 import { VideoAnalysisContent } from "./_components/video-analysis-content";
 
-export default async function VideoAnalysisPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ raid?: string }>;
-}) {
-  const { raid } = await searchParams;
-
-  return <VideoAnalysisContent initialRaid={raid || "all"} />;
+// Reading searchParams on the server made this the only plain route rendered
+// on demand, and every visit to it invoked a function. The child is a client
+// component, so it can read the query itself. Dropping the Suspense boundary
+// fails the prerender of /video-analysis, and without the fallback the
+// prerendered body is empty until hydration.
+export default function VideoAnalysisPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <VideoAnalysisContent />
+    </Suspense>
+  );
 }

--- a/src/components/features/combo/combo-selector.tsx
+++ b/src/components/features/combo/combo-selector.tsx
@@ -65,6 +65,7 @@ function StudentSlot({
         height={48}
         className="object-cover rounded w-full h-full"
         draggable={false}
+        unoptimized
       />
       {onClear && (
         <button
@@ -171,6 +172,7 @@ export default function ComboSelector() {
                         selected ? "" : "grayscale opacity-70"
                       }`}
                       draggable={false}
+                      unoptimized
                     />
                     {modeIcon && (
                       <div className="absolute bottom-0 right-0 bg-gray-700/90 text-white rounded-sm p-0.5">

--- a/src/components/features/pool/pool-student-tile.tsx
+++ b/src/components/features/pool/pool-student-tile.tsx
@@ -73,7 +73,7 @@ function PoolStudentTileInner({
         className={`object-cover rounded mb-1 ${owned ? "" : "grayscale opacity-60"}`}
         draggable={false}
         loading="lazy"
-        quality={75}
+        unoptimized
       />
       <div className="text-xs text-center w-full truncate" title={name}>
         {name}

--- a/src/components/features/student/student-image.tsx
+++ b/src/components/features/student/student-image.tsx
@@ -88,7 +88,11 @@ export function StudentImage({
                 className={`object-cover rounded mb-1 ${borderClass}`}
                 draggable={false}
                 loading="lazy"
-                quality={75}
+                // The CDN already serves these as webp at icon size, so the
+                // optimizer had nothing to gain and every icon still cost a
+                // request and its bandwidth on the host: student icons alone
+                // were 60% of all requests to the site.
+                unoptimized
                 placeholder="empty"
               />
               {showModeBadge && modeIcon && (

--- a/src/components/features/video/searchable-select.tsx
+++ b/src/components/features/video/searchable-select.tsx
@@ -40,6 +40,7 @@ const OptionImage = ({ value, label }: { value: string | number; label: string }
       height={16}
       className="rounded object-cover flex-shrink-0"
       onError={() => setError(true)}
+      unoptimized
     />
   );
 }


### PR DESCRIPTION
Netlify usage on this site was running at roughly 4,139 requests, 21.7 MB, and 460 function invocations per hour. `/_next/image` alone was 60% of the requests and 37% of the bandwidth. Three causes, three fixes.

## Cache headers

Every response carried `Cache-Control: public, max-age=0, must-revalidate`. The CDN stored pages and images and then revalidated on each hit, so the cache never actually served anything. `netlify.toml` now sets a durable 10 minute CDN TTL site-wide, 30 days for `/_next/image`, and 1 day for the favicon.

## Student icons skip the optimizer

Student icons are 40-72px WebP files already served from the CDN. Routing them through the Next image optimizer produced no smaller file and cost a Netlify request plus bandwidth each time. They are `unoptimized` now, so the browser fetches them from the CDN directly. Four call sites: `student-image`, `pool-student-tile`, `combo-selector`, `searchable-select`.

YouTube thumbnails stay optimized. `maxresdefault` is 1280x720 and renders around 400px, so the optimizer earns its cost there.

## /video-analysis prerenders

The page read `searchParams` on the server, which made it the only plain route rendered on demand and invoked a function on every visit. The child is already a client component, so it reads the query with `useSearchParams()` instead. The Suspense boundary is required for the prerender to succeed, and its fallback keeps the loading spinner in the static HTML.

No behavior change. The `?raid=` query works as before, and data was already fetched client-side.

## Verification

Lint, types and build pass. The build route table shows `/video-analysis` as static, leaving 4 dynamic routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)